### PR TITLE
5 jump back and forth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Overview
-Ever wanted a way to jump to the `Nth` desktop on Windows 10 or 11 with a keyboard shortcut? WinJump allows you to create custom shortcuts to jump to a specific desktop or cycle between a predefined group of desktops.
+Ever wanted to jump directly to your `Nth` desktop on Windows 10 or 11 with a keyboard shortcut of your choice? WinJump enables you to create custom shortcuts to jump to any desktop and cycle between groups of desktops.
 
-WinJump uses the excellent [VirtualDesktop](https://github.com/MScholtes/VirtualDesktop) library. Most other solutions use an [AutoHotKey](https://www.autohotkey.com/) based solution which automates pressing the Windows built-in `WINDOWS_KEY + CTRL + [LEFT ARROW OR RIGHT ARROW]` shortcut a number of times in a row. 
-This often results in glitchly visuals and lagging while jumping to the desktop you want. VirtualDesktop instead immediately jumps to the desired desktop.
+Most other solutions use an [AutoHotKey](https://www.autohotkey.com/) based solution which automates pressing the Windows default shortuct <kbd>Win</kbd> + <kbd>Ctrl</kbd> + <kbd>Left Arrow</kbd> or <kbd>Right Arrow</kbd> multiple times. 
+This often results in glitchly visuals and lagging while jumping to the desktop you want.
+WinJump uses the excellent [VirtualDesktop](https://github.com/MScholtes/VirtualDesktop) library which jumps directly to the desired desktop.
 
 # Installation
 ## Supported versions
@@ -11,13 +12,14 @@ Currently, the following versions of Windows are supported:
 | ----------- | ----------- |
 | Windows 10      | 1607-1709, 1803, 1809 - 21H2       |
 | Windows 11   | 21H2, 22H2       |
+
 ## How to install
-1) [Download](https://github.com/widavies/WinJump/releases/download/1.4.0/Release_1_4_0.zip)
-2) Extract and run `setup.exe`
-3) You're done! WinJump will start automatically and will register itself to start when your computer boots.
+1. [Download](https://github.com/widavies/WinJump/releases/download/1.4.0/Release_1_4_0.zip)
+2. Extract and run *setup.exe*
+3. You're done! WinJump will start automatically and will register itself to start when your computer boots.
 
 ## Config file
-You can optionally include a configuration file named `.winjump` in your home directory to change default behavior.
+You can optionally include a configuration file named *.winjump* in your home directory to change the default behavior.
 
 ### Syntax
 There are two blocks:
@@ -29,67 +31,69 @@ Both blocks contain a list of items, each item has a `shortcut` property. This s
 `win`, `alt`, `shift`, and `ctrl`, it must be terminated by a key listed [here](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.keys?view=windowsdesktop-7.0),
 and each token must be separated by `+`.
 
-Each toggle group has the `desktops` property, which should be a list of positive integers, with `1` representing the first desktop.
+Each `toggle-groups` item has the `desktops` property, which should be a list of positive integers, with `1` representing the first desktop.
 
-Each jump to item has the `desktop` property, which should be a single positive integer, with `1` representing the first desktop.
+Each `jump-to` item has the `desktop` property, which should be a single positive integer, with `1` representing the first desktop.
 
-> Warning: If no `.winjump` config file is found or a syntax error exists within it, WinJump will revert to the default key mappings.
+> ⚠️ If no *.winjump* config file is found or a syntax error exists within it, WinJump will use default key mappings.
 
-WinJump does not auto-reload your configuration file. You must either launch task manager, kill `WinJump`, then launch it again from the start menu or reboot.
+> ⚠️ WinJump does not auto-reload your configuration file. To apply changes, restart WinJump via one of the following methods:
+> - launch task manager, kill WinJump, launch it again from the start menu
+> - log out and back in
+> - reboot
 
 ### Example
 Below is an example configuration file that changes the shortcut to `alt+N` to jump to a desktop and adds a toggle group that is triggered by `alt+w` that will cycle between desktops `1`, `5`, and `6`:
 
-```
-C:\Users\<UserName>\.winjump
-
+```jsonc
+// C:\Users\<UserName>\.winjump
 {
   "toggle-groups": [
     {
       "shortcut": "alt+w",
-      "desktops": [1, 5, 6]
+      "desktops": [ 1, 5, 6 ]
     }
   ],
   "jump-to": [
-     {
-       shortcut: "alt+d1",
-       desktop: 1
-     },
-     {
-       shortcut: "alt+d2",
-       desktop: 2
-     },
-     {
-       shortcut: "alt+d3",
-       desktop: 3
-     },
-     {
-       shortcut: "alt+d4",
-       desktop: 4
-     },
-     {
-       shortcut: "alt+d5",
-       desktop: 5
-     },
-     {
-       shortcut: "alt+d6",
-       desktop: 6
-     },
-     {
-       shortcut: "alt+d7",
-       desktop: 7
-     },
-     {
-       shortcut: "alt+d8",
-       desktop: 8
-     },
-     {
-       shortcut: "alt+d9",
-       desktop: 9
-     },
-     {
-       shortcut: "alt+d0",
-       desktop: 10
+    {
+      "shortcut": "alt+d1",
+      "desktop": 1
+    },
+    {
+      "shortcut": "alt+d2",
+      "desktop": 2
+    },
+    {
+      "shortcut": "alt+d3",
+      "desktop": 3
+    },
+    {
+      "shortcut": "alt+d4",
+      "desktop": 4
+    },
+    {
+      "shortcut": "alt+d5",
+      "desktop": 5
+    },
+    {
+      "shortcut": "alt+d6",
+      "desktop": 6
+    },
+    {
+      "shortcut": "alt+d7",
+      "desktop": 7
+    },
+    {
+      "shortcut": "alt+d8",
+      "desktop": 8
+    },
+    {
+      "shortcut": "alt+d9",
+      "desktop": 9
+    },
+    {
+      "shortcut": "alt+d0",
+      "desktop": 10
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ Most other solutions use an [AutoHotKey](https://www.autohotkey.com/) based solu
 This often results in glitchly visuals and lagging while jumping to the desktop you want.
 WinJump uses the excellent [VirtualDesktop](https://github.com/MScholtes/VirtualDesktop) library which jumps directly to the desired desktop.
 
+# Features
+## Jump To
+Jump directly to a desktop with <kbd>Win</kbd> + [ <kbd>0</kbd> - <kbd>9</kbd> ] *(default)*.
+
+## Toggle Groups
+Cycle through a group of desktops with a single shortcut *(there are no groups by default)*.
+
+## Back and Forth
+Pressing the shortcut for the desktop you are currently on will jump back to the last desktop you were on.
+
 # Installation
 ## Supported versions
 Currently, the following versions of Windows are supported:

--- a/WinJump/Program.cs
+++ b/WinJump/Program.cs
@@ -103,6 +103,12 @@ namespace WinJump {
             public void JumpTo(int index) {
                 if (ctx == null) throw new ObjectDisposedException("STAThread");
 
+                int currentDesktop = vdw.GetDesktop();
+                if (index == currentDesktop) {
+                    index = lastDesktop;
+                }
+                lastDesktop = currentDesktop;
+
                 ctx.Send((_) => {
                     vdw.JumpTo(index);
                 }, null);
@@ -138,6 +144,7 @@ namespace WinJump {
             }
 
             private SynchronizationContext ctx;
+            private int lastDesktop;
             private readonly ManualResetEvent mre;
         }
     }


### PR DESCRIPTION
Implement feature to jump back to previous desktop

When the shortcut for the current desktop is pressed, the last desktop
is jumped to instead. Enables users to jump back and forth between two
desktops by repeatedly pressing the same shortcut.

I also touched up the formatting in the readme and reworded a few things.
If you don't like anything, let me know, I'd be happy to revert it.

closes #5