### PR TITLE
Fix move window and jump into a virtual desktop that doesn't exist.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+.vs/

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows10_17763.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows10_17763.cs
@@ -117,6 +117,7 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 GetWindowThreadProcessId(hWnd, out processId);
 
                 var desktop = GetDesktop(index);
+                if (desktop == null) return;
 
                 if(Environment.ProcessId == processId) {
                     // window of process

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows11_22000.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows11_22000.cs
@@ -117,6 +117,7 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 GetWindowThreadProcessId(hWnd, out processId);
 
                 var desktop = GetDesktop(index);
+                if (desktop == null) return;
 
                 if(Environment.ProcessId == processId) {
                     // window of process

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows11_22621.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows11_22621.cs
@@ -115,6 +115,7 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 GetWindowThreadProcessId(hWnd, out processId);
 
                 var desktop = GetDesktop(index);
+                if (desktop == null) return;
                 
                 if(Environment.ProcessId == processId) {
                     // window of process

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows11_22621_2215.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows11_22621_2215.cs
@@ -117,6 +117,7 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 GetWindowThreadProcessId(hWnd, out processId);
 
                 var desktop = GetDesktop(index);
+                if (desktop == null) return;
 
                 if(Environment.ProcessId == processId) {
                     // window of process

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows11_22631_3085.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows11_22631_3085.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 
 namespace WinJump.Core.VirtualDesktopDefinitions {
@@ -117,6 +117,7 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 GetWindowThreadProcessId(hWnd, out processId);
 
                 var desktop = GetDesktop(index);
+                if (desktop == null) return;
 
                 if(Environment.ProcessId == processId) {
                     // window of process


### PR DESCRIPTION
Currently if you try to move a window into an virtual desktop that doesn't exist windows explorer crashes.
This PR fixes that by exiting early if no desktop is found.

Issue observed on Windows 11 build 22631.3880

Fix tested on Windows 11 build 22631.3880