### PR TITLE
Fix issue when trying to jump to active window or non existent virtual desktop

### DIFF
--- a/WinJump/Core/VirtualDesktopDefinitions/IVirtualDesktopAPI.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/IVirtualDesktopAPI.cs
@@ -21,6 +21,12 @@ public interface IVirtualDesktopAPI : IDisposable {
     int GetCurrentDesktop();
 
     /// <summary>
+    /// Returns how many virtual desktops there are.
+    /// </summary>
+    /// <returns>Virtual desktop count</returns>
+    public int GetDesktopCount();
+
+    /// <summary>
     /// Jumps to the virtual desktop.
     /// </summary>
     /// <param name="index">0-indexed desktop number. If it is invalid it will be ignored.</param>

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows10_17763.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows10_17763.cs
@@ -17,6 +17,10 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 return DesktopManager.GetCurrentDesktopNum();
             }
 
+            public int GetDesktopCount() {
+                return DesktopManager.GetDesktopCount();
+            }
+
             public void JumpToDesktop(int index) {
                 DesktopManager.SwitchDesktop(index);
             }
@@ -108,6 +112,10 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 var vd = VirtualDesktopManagerInternal.GetCurrentDesktop();
 
                 return GetIndex(vd);
+            }
+
+            internal static int GetDesktopCount() {
+                return VirtualDesktopManagerInternal.GetCount();
             }
 
             internal static void MoveCurrentlyFocusedToDesktop(int index) {

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows11_22000.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows11_22000.cs
@@ -17,6 +17,10 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 return DesktopManager.GetCurrentDesktopNum();
             }
 
+            public int GetDesktopCount() {
+                return DesktopManager.GetDesktopCount();
+            }
+
             public void JumpToDesktop(int index) {
                 DesktopManager.SwitchDesktop(index);
             }
@@ -108,6 +112,10 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 var vd = VirtualDesktopManagerInternal.GetCurrentDesktop(IntPtr.Zero);
 
                 return GetIndex(vd);
+            }
+
+            internal static int GetDesktopCount() {
+                return VirtualDesktopManagerInternal.GetCount(IntPtr.Zero);
             }
 
             internal static void MoveCurrentlyFocusedToDesktop(int index) {

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows11_22621.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows11_22621.cs
@@ -17,6 +17,10 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 return DesktopManager.GetCurrentDesktopNum();
             }
 
+            public int GetDesktopCount() {
+                return DesktopManager.GetDesktopCount();
+            }
+
             public void JumpToDesktop(int index) {
                 DesktopManager.SwitchDesktop(index);
             }
@@ -106,6 +110,10 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 var vd = VirtualDesktopManagerInternal.GetCurrentDesktop(IntPtr.Zero);
 
                 return GetIndex(vd);
+            }
+
+            internal static int GetDesktopCount() {
+                return VirtualDesktopManagerInternal.GetCount(IntPtr.Zero);
             }
             
             internal static void MoveCurrentlyFocusedToDesktop(int index) {

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows11_22621_2215.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows11_22621_2215.cs
@@ -17,6 +17,10 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 return DesktopManager.GetCurrentDesktopNum();
             }
 
+            public int GetDesktopCount() {
+                return DesktopManager.GetDesktopCount();
+            }
+
             public void JumpToDesktop(int index) {
                 DesktopManager.SwitchDesktop(index);
             }
@@ -108,6 +112,10 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 var vd = VirtualDesktopManagerInternal.GetCurrentDesktop();
 
                 return GetIndex(vd);
+            }
+
+            internal static int GetDesktopCount() {
+                return VirtualDesktopManagerInternal.GetCount();
             }
 
             internal static void MoveCurrentlyFocusedToDesktop(int index) {

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows11_22631_3085.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows11_22631_3085.cs
@@ -17,6 +17,10 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 return DesktopManager.GetCurrentDesktopNum();
             }
 
+            public int GetDesktopCount() {
+                return DesktopManager.GetDesktopCount();
+            }
+
             public void JumpToDesktop(int index) {
                 DesktopManager.SwitchDesktop(index);
             }
@@ -108,6 +112,10 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 var vd = VirtualDesktopManagerInternal.GetCurrentDesktop();
 
                 return GetIndex(vd);
+            }
+
+            internal static int GetDesktopCount() {
+                return VirtualDesktopManagerInternal.GetCount();
             }
 
             internal static void MoveCurrentlyFocusedToDesktop(int index) {

--- a/WinJump/Core/WinJumpManager.cs
+++ b/WinJump/Core/WinJumpManager.cs
@@ -251,9 +251,24 @@ internal sealed class STAThread : IDisposable {
     }
 
     public void JumpTo(uint index) {
+ 
+        var allowJump = true;
         WrapCall(() => {
-            api.JumpToDesktop((int) index);
-        }, true);
+            // If the desktop is the same as the current one or doesn't exist, don't allow the jump
+            if(api.GetCurrentDesktop() == index) {
+                allowJump = false;
+            }
+            else if(index >= api.GetDesktopCount())
+            {
+                allowJump = false;
+            }
+        });
+
+        if(allowJump) {
+            WrapCall(() => {
+                api.JumpToDesktop((int) index);
+            }, true);
+        }
     }
 
     public void JumpToNoHack(uint index) {


### PR DESCRIPTION
Fixes issue with desktop flickering and loosing window focus when trying to jump to active window or non existent window.
The flickering bug is probably due too the hacky window focus code since if when tried to do these checks inside the DesktopManager the issue persisted.

This can probably be written cleaner, but this should work.

Observed on Windows 10, not sure about version but newish and Windows 11 build 22631.3880

Tested on Windows 11 build 22631.3880