### PR TITLE
Add sticky desktops with config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ There are three blocks:
 - `jump-to` lets you define shortcuts that jump directly to a desktop
 - `move-window-to-desktop` lets you specify a custom shortcut modifier. When pressed, the currently focused window will be moved to the desktop specified by the number key you press.
 - `change-desktops-with-scroll` should desktops automatically switch by scrolling over the taskbar?
+- `sticky-desktops` lets you set an amount of virtual desktops to be created when WinJump starts (max of 10)
 
 The `toggle-groups` and `jump-to` blocks contain a list of items, each item has a `shortcut` property. This shortcut must be a combination of:
 `win`, `alt`, `shift`, and `ctrl`, it must be terminated by a key listed [here](https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.keys?view=windowsdesktop-7.0),
@@ -62,6 +63,7 @@ Below is an example configuration file that changes the shortcut to `alt+N` to j
     }
   ],
   "jump-current-goes-to-last": false,
+  "sticky-desktops": 4,
   "move-window-to": [
     {
       "shortcut": "alt+shift+d1",

--- a/WinJump/Core/Config.cs
+++ b/WinJump/Core/Config.cs
@@ -11,6 +11,7 @@ namespace WinJump.Core;
 /// Handles loading the configuration file
 /// </summary>
 internal sealed class Config {
+    public static readonly int MAX_STICKY_DESKTOPS = 10;
     public static readonly string LOCATION = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
         ".winjump");
@@ -29,6 +30,9 @@ internal sealed class Config {
 
     [JsonProperty("change-desktops-with-scroll")]
     public required bool ChangeDesktopsWithScroll { get; set; }
+    
+    [JsonProperty("sticky-desktops")]
+    public int StickyDesktops { get; set; }
 
     public static Config Load() {
         try {
@@ -128,7 +132,8 @@ internal sealed class Config {
             JumpTo = jumpTo,
             ToggleGroups = [],
             JumpCurrentGoesToLast = true,
-            ChangeDesktopsWithScroll = false
+            ChangeDesktopsWithScroll = false,
+            StickyDesktops = 0
         };
     }
 }

--- a/WinJump/Core/VirtualDesktopDefinitions/IVirtualDesktopAPI.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/IVirtualDesktopAPI.cs
@@ -21,6 +21,11 @@ public interface IVirtualDesktopAPI : IDisposable {
     int GetCurrentDesktop();
 
     /// <summary>
+    /// Creates a new virtual desktop
+    /// </summary>
+    void CreateDesktop();
+
+    /// <summary>
     /// Returns how many virtual desktops there are.
     /// </summary>
     /// <returns>Virtual desktop count</returns>

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows10_17763.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows10_17763.cs
@@ -13,6 +13,11 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 });
             }
 
+            public void CreateDesktop()
+            {
+                DesktopManager.CreateDesktop();
+            }
+
             public int GetCurrentDesktop() {
                 return DesktopManager.GetCurrentDesktopNum();
             }
@@ -106,6 +111,10 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 if(desktop == null) return;
                 VirtualDesktopManagerInternal.SwitchDesktop(desktop);
                 Marshal.ReleaseComObject(desktop);
+            }
+
+            internal static void CreateDesktop() {
+                VirtualDesktopManagerInternal.CreateDesktop();
             }
 
             internal static int GetCurrentDesktopNum() {

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows11_22000.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows11_22000.cs
@@ -12,6 +12,11 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                     OnDesktopChanged = desktop => { OnDesktopChanged?.Invoke(desktop); }
                 });
             }
+            
+            public void CreateDesktop()
+            {
+                DesktopManager.CreateDesktop();
+            }
 
             public int GetCurrentDesktop() {
                 return DesktopManager.GetCurrentDesktopNum();
@@ -106,6 +111,11 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 if(desktop == null) return;
                 VirtualDesktopManagerInternal.SwitchDesktop(IntPtr.Zero, desktop);
                 Marshal.ReleaseComObject(desktop);
+            }
+
+            internal static void CreateDesktop()
+            {
+                VirtualDesktopManagerInternal.CreateDesktop(IntPtr.Zero);
             }
 
             internal static int GetCurrentDesktopNum() {

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows11_22621.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows11_22621.cs
@@ -13,6 +13,11 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 });
             }
 
+            public void CreateDesktop()
+            {
+                DesktopManager.CreateDesktop();
+            }
+
             public int GetCurrentDesktop() {
                 return DesktopManager.GetCurrentDesktopNum();
             }
@@ -104,6 +109,11 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 if(desktop == null) return;
                 VirtualDesktopManagerInternal.SwitchDesktop(IntPtr.Zero, desktop);
                 Marshal.ReleaseComObject(desktop);
+            }
+
+            internal static void CreateDesktop()
+            {
+                VirtualDesktopManagerInternal.CreateDesktop(IntPtr.Zero);
             }
 
             internal static int GetCurrentDesktopNum() {

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows11_22621_2215.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows11_22621_2215.cs
@@ -13,6 +13,11 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 });
             }
 
+            public void CreateDesktop()
+            {
+                DesktopManager.CreateDesktop();
+            }
+
             public int GetCurrentDesktop() {
                 return DesktopManager.GetCurrentDesktopNum();
             }
@@ -106,6 +111,10 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 if(desktop == null) return;
                 VirtualDesktopManagerInternal.SwitchDesktop(desktop);
                 Marshal.ReleaseComObject(desktop);
+            }
+
+            internal static void CreateDesktop() {
+                VirtualDesktopManagerInternal.CreateDesktop();
             }
 
             internal static int GetCurrentDesktopNum() {

--- a/WinJump/Core/VirtualDesktopDefinitions/Windows11_22631_3085.cs
+++ b/WinJump/Core/VirtualDesktopDefinitions/Windows11_22631_3085.cs
@@ -12,6 +12,11 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                     OnDesktopChanged = desktop => { OnDesktopChanged?.Invoke(desktop); }
                 });
             }
+            
+            public void CreateDesktop()
+            {
+                DesktopManager.CreateDesktop();
+            }
 
             public int GetCurrentDesktop() {
                 return DesktopManager.GetCurrentDesktopNum();
@@ -106,6 +111,11 @@ namespace WinJump.Core.VirtualDesktopDefinitions {
                 if(desktop == null) return;
                 VirtualDesktopManagerInternal.SwitchDesktop(desktop);
                 Marshal.ReleaseComObject(desktop);
+            }
+
+            internal static void CreateDesktop()
+            {
+                VirtualDesktopManagerInternal.CreateDesktop();
             }
 
             internal static int GetCurrentDesktopNum() {

--- a/WinJump/Core/WinJumpManager.cs
+++ b/WinJump/Core/WinJumpManager.cs
@@ -147,6 +147,12 @@ public class WinJumpManager : IDisposable {
             desktopChanged(_lightMode, desktop);
         });
 
+        // Create sticky desktops config
+        var desktopsToCreate = int.Clamp(config.StickyDesktops - _thread.GetDesktopCount(), 0, Config.MAX_STICKY_DESKTOPS);
+        for (var i = 0; i < desktopsToCreate; i++) {
+            _thread?.CreateDesktop();
+        }
+
         // This particular event fires immediately on initial register
         _explorerMonitor.OnColorSchemeChanged += lightMode => {
             _lightMode = lightMode;
@@ -225,10 +231,15 @@ internal sealed class STAThread : IDisposable {
         }
     }
 
-    // public void BeginInvoke(Delegate dlg, params Object[] args) {
-    //     if (ctx == null) throw new ObjectDisposedException("STAThread");
-    //     ctx.Post(_ => dlg.DynamicInvoke(args), null);
-    // }
+    public void CreateDesktop() {
+        WrapCall(() => {
+            api.CreateDesktop();
+        });
+    }
+
+    public int GetDesktopCount() {
+        return api.GetDesktopCount();
+    }
 
     public int GetCurrentDesktop() {
         if(ctx == null) throw new ObjectDisposedException("STAThread");


### PR DESCRIPTION
Adds a new feature called Sticky Desktops that will ensure a minimum amount of virtual desktops are always available when WinJump starts.

The default configuration sets `sticky-desktops` to 0. A hardcoded max of 10 is used to keep a clamped range of desktops that can be created.

Tested on Windows 23H2 (22631.4169)

Closes #52 