### PR TITLE
Focus timing Issue #27

### DIFF
--- a/WinJump/Core/WinJumpManager.cs
+++ b/WinJump/Core/WinJumpManager.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using WinJump.Core.VirtualDesktopDefinitions;
 using WinJump.UI;
@@ -340,7 +341,7 @@ internal sealed class STAThread : IDisposable {
                     }
                 }
 
-                action.Invoke();
+                Task.Run(() => { action.Invoke(); }); 
 
                 if(performWindowFocusHack) {
                     IntPtr wnd = FindWindow(null, "Program Manager");


### PR DESCRIPTION
Should resolve #27 

From what I've read in several threads a timing issue was suspected.
This gave me a Javascriptish type of an idea :D

I was able to replicate focus working correctly while debugging.
I was able to replicate focus consistently failing without debugging.

After adding this it seems to be consistently succeeding without debugging.

Tried disabling the `performWindowFocusHack` but that seems to be still required.
Consider if there could be any side effects because of the change as I am still not super familiar with the application 😅.